### PR TITLE
Reorder and fix bug in maximise and minimise

### DIFF
--- a/resources/js/emulateMacOS_rightAlign.js
+++ b/resources/js/emulateMacOS_rightAlign.js
@@ -32,13 +32,13 @@ try {
         const redStoplightStyle = "height: 11px; width: 11px; background-color: rgb(255, 92, 92); border-radius: 50%; display: inline-block; float: right; top: 0px; margin: 10px 10px 10px 4px; color: rgb(130, 0, 5); fill: rgb(130, 0, 5); -webkit-app-region: no-drag; ";
         const redStoplightOnClick = "ipcRenderer.send('close');";
 
+        /* Green - Maximize */
+        const greenStoplightStyle = "height: 11px; width: 11px; background-color: rgb(0, 202, 86); border-radius: 50%; display: inline-block; float: right; top: 0px; margin: 10px 4px 10px; color: rgb(130, 0, 5); fill: rgb(130, 0, 5); -webkit-app-region: no-drag;";
+        const greenStoplightOnClick = "ipcRenderer.send('maximize');";
+        
         /* Yellow - Minimize */
         const yellowStoplightStyle = "height: 11px; width: 11px; background-color: rgb(255, 189, 76); border-radius: 50%; display: inline-block; float: right; top: 0px; margin: 10px 4px; color: rgb(130, 0, 5); fill: rgb(130, 0, 5); -webkit-app-region: no-drag;";
-        const yellowStoplightOnClick = "ipcRenderer.send('maximize');";
-
-        /* Green - Maximize */
-        const greenStoplightStyle = "height: 11px; width: 11px; background-color: rgb(0, 202, 86); border-radius: 50%; display: inline-block; float: right; top: 0px; margin: 10px 4px 10px 10px; color: rgb(130, 0, 5); fill: rgb(130, 0, 5); -webkit-app-region: no-drag;";
-        const greenStoplightOnClick = "ipcRenderer.send('minimize');";
+        const yellowStoplightOnClick = "ipcRenderer.send('minimize');";
 
         /* Dim the Button Function */
         function dimButton(id) {
@@ -61,8 +61,8 @@ try {
                 </div>
                 <div class="mainDragDiv" style="background-color: var(--playerBackground); top: 0; -webkit-app-region: drag; -webkit-user-select: none; flex-grow: 1; height: 32px;">
                     <span id="red" onmouseover="dimButton('red')" onmouseleave="brightenButton('red')" onclick="${redStoplightOnClick}" style="${redStoplightStyle}"></span>
-                    <span id="yellow" onmouseover="dimButton('yellow')" onmouseleave="brightenButton('yellow')" onclick="${yellowStoplightOnClick}" style="${yellowStoplightStyle}"></span>
                     <span id="green" onmouseover="dimButton('green')" onmouseleave="brightenButton('green')" onclick="${greenStoplightOnClick}" style="${greenStoplightStyle}"></span>
+                    <span id="yellow" onmouseover="dimButton('yellow')" onmouseleave="brightenButton('yellow')" onclick="${yellowStoplightOnClick}" style="${yellowStoplightStyle}"></span>
                 </div>
             </div>
         `);


### PR DESCRIPTION
There is currently a bug in MacOS emulation mode (right-align) with the green button minimising the application and yellow maximising the application. This corrects that issue and reorders them to be in the same order as Windows (minimise, maximise, close).

Currently (green minimises):
![image](https://user-images.githubusercontent.com/5961364/129555349-422ca312-fe16-44c2-a81b-7037cccb6bec.png)

This PR (green maximises):
![image](https://user-images.githubusercontent.com/5961364/129557307-f24c290e-9370-40b6-911b-5cead29ac45c.png)