### PR TITLE
Adds a context menu on right click (on song entries)

### DIFF
--- a/resources/functions/load.js
+++ b/resources/functions/load.js
@@ -111,6 +111,8 @@ module.exports = {
           app.funcs.LoadJS('macOS.js')
         }
 
+        app.funcs.LoadJS("addContextMenu.js")
+
         app.funcs.LoadJS('custom.js')
 
         function matchRuleShort(str, rule) {

--- a/resources/js/addContextMenu.js
+++ b/resources/js/addContextMenu.js
@@ -1,0 +1,30 @@
+try {
+    let simulateClick = function (element, clientX, clientY) {
+        let event = new MouseEvent('click', {
+            clientX: clientX,
+            clientY: clientY
+        });
+
+        element.dispatchEvent(event);
+    };
+
+    let songControlls = document.getElementsByClassName("songs-list-row");
+
+    if (songControlls.length === 0) {
+        songControlls = document.getElementsByClassName("library-track");
+    }
+
+    for (let songControll of songControlls) {
+        songControll.addEventListener('contextmenu', function (event) {
+            event.preventDefault();
+
+            let controll = songControll.getElementsByClassName("context-menu__overflow ")[0];
+
+            if (controll) {
+                simulateClick(controll, event.clientX, event.clientY);
+            }
+        });
+    }
+} catch (e) {
+    console.error("[JS] Error while trying to apply addContextMenu.js", e);
+}


### PR DESCRIPTION
Creates the context menu which appears when you click the 'more' button (three dot icon) at the cursor position when you right click on a song

The created context menu belongs to the specific element you right clicked on

'library-track' is used in the titles page
'songs-list-row' seems to be used in the other places

Apple already does it on the artist page

![image](https://user-images.githubusercontent.com/22003703/133911324-987cbb61-3982-41ba-97bf-10f2e2c9c394.png)

(Also is it only me or do comments on the loaded js files cause it to not being able to load them? Only worked after I removed them - got an 'Uncaught SyntaxError: Unexpected end of input' error)