### PR TITLE
Fix #293 - Cannot read properties of null(reading 'setAttribute')

### DIFF
--- a/resources/js/MusicKitInterop.js
+++ b/resources/js/MusicKitInterop.js
@@ -15,20 +15,20 @@ const MusicKitInterop = {
                 const nowPlayingItem = MusicKit.getInstance().nowPlayingItem;
                 if (typeof nowPlayingItem != "undefined") {
                     if (nowPlayingItem["type"] === "musicVideo") {
-                        document.querySelector(`div[aria-label="Media Controls"]`).setAttribute('style', 'height: 20px !important');
+                        document.querySelector(`.web-chrome`).setAttribute('style', 'height: 20px !important');
                     } else {
-                        document.querySelector(`div[aria-label="Media Controls"]`).setAttribute('style', 'height: 55px !important');
+                        document.querySelector(`.web-chrome`).setAttribute('style', 'height: 55px !important');
                     }
                 }
             } else {
-                document.querySelector(`div[aria-label="Media Controls"]`).setAttribute('style', 'height: 55px !important');
+                document.querySelector(`.web-chrome`).setAttribute('style', 'height: 55px !important');
                 try {
                     const nowPlayingItem = MusicKit.getInstance().nowPlayingItem;
                     if (typeof nowPlayingItem != "undefined") {
                         if (nowPlayingItem["type"] === "musicVideo") {
-                            document.querySelector(`div[aria-label="Media Controls"]`).setAttribute('style', 'height: 20px !important');
+                            document.querySelector(`.web-chrome`).setAttribute('style', 'height: 20px !important');
                         } else {
-                            document.querySelector(`div[aria-label="Media Controls"]`).setAttribute('style', 'height: 55px !important');
+                            document.querySelector(`.web-chrome`).setAttribute('style', 'height: 55px !important');
                         }
                     }
                 } catch (e) {


### PR DESCRIPTION
## About
When the aria-label from the Media Controls div get translated, the div become unreachable through the aria-label and throws errors like this one:
![image](https://user-images.githubusercontent.com/58451227/138787487-e7c444b1-127d-4d6e-9bc4-f90ba8030204.png)

This error caused the auto-play to stop working on the radio. To play every music, it's necessary a manual skip after each song. To get out of the radio, it needs to clean the song queue manually. It bugs the playlist too, where it needs to clean the song queue before changing the playlist.

Solves #293

## Implements
This PR changed the way to get the Media Controls div from the aria-label to the className on the MusicKitInterop.