### PR TITLE
Changed instances of "seemless" to "seamless"

### DIFF
--- a/resources/functions/app-init.js
+++ b/resources/functions/app-init.js
@@ -77,7 +77,7 @@ module.exports = () => {
         },
         audio: {
             audioQuality: "auto",
-            seemlessAudioTransitions: false
+            seamlessAudioTransitions: false
         },
         window: {
             appStartupBehavior: "",

--- a/resources/functions/handler.js
+++ b/resources/functions/handler.js
@@ -95,7 +95,7 @@ const handler = {
             app.ame.win.CreateNotification(a);
             app.ame.mpris.updateActivity(a);
 
-            if (app.cfg.get('audio.seemlessAudioTransitions')) {
+            if (app.cfg.get('audio.seamlessAudioTransitions')) {
                 app.ame.win.SetButtons()
                 app.ame.win.SetTrayTooltip(a)
                 app.ame.discord.updateActivity(a)

--- a/resources/html/oobe.html
+++ b/resources/html/oobe.html
@@ -325,12 +325,12 @@
                         </div>
                         <div class="md-option-line">
                             <div class="md-option-segment">
-                                Seemless Audio Transitions
+                                Seamless Audio Transitions
                                 <br>
                                 <small>Reduces or completely removes the delay between songs providing a smooth audio experience.</small>
                             </div>
                             <div class="md-option-segment md-option-segment_auto">
-                                <input type="checkbox" v-model="prefs.audio.seemlessAudioTransitions" switch/>
+                                <input type="checkbox" v-model="prefs.audio.seamlessAudioTransitions" switch/>
                             </div>
                         </div>
                         <div class="md-option-line">

--- a/resources/html/preferences-main.html
+++ b/resources/html/preferences-main.html
@@ -593,9 +593,9 @@
                     high CPU Usage.</span>
             </li>
             <li class="app-prefs-toggle">
-                <span class="typography-title-3-tall">Seemless Audio Transitions</span>
+                <span class="typography-title-3-tall">Seamless Audio Transitions</span>
                 <label class="toggle-element list-element">
-                    <input checked id="seemlessAudioTransitions" type="checkbox">
+                    <input checked id="seamlessAudioTransitions" type="checkbox">
                     <span class="slider"></span>
                 </label>
                 <span class="app-prefs-help typography-title-3-tall">Reduces or completely removes the delay between

--- a/resources/js/custom.js
+++ b/resources/js/custom.js
@@ -793,10 +793,9 @@ try {
                     MusicKit.getInstance().bitrate = 64;
                 }
 
-                /* Seemless (Apple dont know how to spell) Audio Playback */
-                if (preferences.audio.seemlessAudioTransitions) {
-                    console.warn("[Custom] Seemless Audio Transitions enabled.");
-                    MusicKit.getInstance()._bag.features["seemless-audio-transitions"] = true;
+                if (preferences.audio.seamlessAudioTransitions) {
+                    console.warn("[Custom] Seamless Audio Transitions enabled.");
+                    MusicKit.getInstance()._bag.features["seamless-audio-transitions"] = true;
                 }
 
                 /* Incognito Mode */
@@ -1253,7 +1252,7 @@ try {
 
                     /* Audio Settings */
                     AMSettings.HandleField('audioQuality');
-                    AMSettings.HandleField('seemlessAudioTransitions');
+                    AMSettings.HandleField('seamlessAudioTransitions');
                     AMSettings.HandleField('volume');
 
                     /* Window Settings */

--- a/resources/js/tests.js
+++ b/resources/js/tests.js
@@ -305,7 +305,7 @@ var _tests = {
                         },
                         audio: {
                             audioQuality: "auto",
-                            seemlessAudioTransitions: true
+                            seamlessAudioTransitions: true
                         },
                         window: {
                             closeButtonMinimize: true
@@ -323,8 +323,8 @@ var _tests = {
                             self.prefs.audio.audioQuality = result
                         })
 
-                        ipcRenderer.invoke("getStoreValue", "audio.seemlessAudioTransitions").then((result) => {
-                            self.prefs.audio.seemlessAudioTransitions = result
+                        ipcRenderer.invoke("getStoreValue", "audio.seamlessAudioTransitions").then((result) => {
+                            self.prefs.audio.seamlessAudioTransitions = result
                         })
 
                         ipcRenderer.invoke("getStoreValue", "general.storefront").then((result) => {
@@ -375,7 +375,7 @@ var _tests = {
                     setPrefs() {
                         let self = this
                         ipcRenderer.invoke("setStoreValue", "audio.audioQuality", self.prefs.audio.audioQuality)
-                        ipcRenderer.invoke("setStoreValue", "audio.seemlessAudioTransitions", self.prefs.audio.seemlessAudioTransitions)
+                        ipcRenderer.invoke("setStoreValue", "audio.seamlessAudioTransitions", self.prefs.audio.seamlessAudioTransitions)
                         ipcRenderer.invoke("setStoreValue", "general.storefront", self.prefs.general.storefront)
                         ipcRenderer.invoke("setStoreValue", "general.discordRPC", self.prefs.general.discordRPC)
                         ipcRenderer.invoke("setStoreValue", "general.analyticsEnabled", self.prefs.general.analyticsEnabled)


### PR DESCRIPTION
MusicKit just updated their "seemlessAudioTransitions" to be spelt
correctly, breaking our current implementation. This just basically
aligns our spelling with MusicKit's.